### PR TITLE
Add playable 4X prototype with core systems and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.tmp/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
 # codex-4x-game
+
+Prototype 4X (Explore, Expand, Exploit, Exterminate) strategy game built with Python, pygame, and pygame_gui.
+
+## Run
+
+```bash
+python -m game.main
+```
+
+## Tests
+
+```bash
+pytest -q
+```
+
+## Lint/Format
+
+```bash
+ruff check .
+black .
+```

--- a/game/config.py
+++ b/game/config.py
@@ -1,0 +1,7 @@
+TILE_SIZE = 32
+UI_BAR_H = 64
+MOVE_COST = {"plains": 1, "forest": 2, "hill": 2, "water": 999}
+YIELD = {"plains": (1, 1), "forest": (0, 2), "hill": (0, 2), "water": (0, 0)}
+UNIT_STATS = {"scout": {"moves": 3, "cost": 3}, "soldier": {"moves": 2, "cost": 4}}
+REVEAL_RADIUS = 3
+START_SIZE = (20, 12)

--- a/game/core/ai.py
+++ b/game/core/ai.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from random import Random
+
+from .. import config
+from . import rules
+from .models import State
+
+
+def ai_take_turn(state: State, rng: Random) -> None:
+    player_id = 1
+    # buy unit if possible
+    for city in state.cities.values():
+        if city.owner == player_id:
+            for kind in ("soldier", "scout"):
+                cost = config.UNIT_STATS[kind]["cost"]
+                if state.players[player_id].prod >= cost:
+                    try:
+                        rules.buy_unit(state, city.id, kind)
+                    except rules.RuleError:
+                        pass
+            break
+    # move units
+    for unit in list(state.units.values()):
+        if unit.owner != player_id:
+            continue
+        # try found city
+        try:
+            rules.found_city(state, unit.id)
+            continue
+        except rules.RuleError:
+            pass
+        dirs = [(0, 1), (1, 0), (-1, 0), (0, -1)]
+        rng.shuffle(dirs)
+        for dx, dy in dirs:
+            dest = (unit.pos[0] + dx, unit.pos[1] + dy)
+            if dest in state.tiles:
+                try:
+                    rules.move_unit(state, unit.id, dest)
+                    break
+                except rules.RuleError:
+                    continue
+
+
+__all__ = ["ai_take_turn"]

--- a/game/core/mapgen.py
+++ b/game/core/mapgen.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from random import Random
+from typing import Dict, List, Tuple
+
+from ..config import UNIT_STATS
+from .models import Tile, Unit
+
+
+def generate_map(
+    w: int, h: int, seed: int
+) -> Tuple[Dict[Tuple[int, int], Tile], List[Tuple[int, int]]]:
+    rng = Random(seed)
+    tiles: Dict[Tuple[int, int], Tile] = {}
+    for y in range(h):
+        for x in range(w):
+            if x in (0, w - 1) or y in (0, h - 1):
+                kind = "water"
+            else:
+                kind = rng.choices(["plains", "forest", "hill", "water"], [6, 2, 2, 1])[
+                    0
+                ]
+            tiles[(x, y)] = Tile(x, y, kind)
+    spawns = [(1, 1), (w - 2, h - 2)]
+    for s in spawns:
+        tiles[s].kind = "plains"
+    return tiles, spawns
+
+
+def initial_units(spawns: List[Tuple[int, int]]) -> List[Unit]:
+    units: List[Unit] = []
+    for owner, pos in enumerate(spawns):
+        u = Unit(
+            id=-1,
+            owner=owner,
+            kind="scout",
+            pos=pos,
+            moves_left=UNIT_STATS["scout"]["moves"],
+        )
+        units.append(u)
+    return units
+
+
+__all__ = ["generate_map", "initial_units"]

--- a/game/core/models.py
+++ b/game/core/models.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+Coord = Tuple[int, int]
+
+
+@dataclass
+class Tile:
+    x: int
+    y: int
+    kind: str
+    revealed_by: set[int] = field(default_factory=set)
+
+
+@dataclass
+class Unit:
+    id: int
+    owner: int
+    kind: str
+    pos: Coord
+    moves_left: int
+
+
+@dataclass
+class City:
+    id: int
+    owner: int
+    pos: Coord
+
+
+@dataclass
+class Player:
+    id: int
+    food: int = 0
+    prod: int = 0
+
+
+@dataclass
+class State:
+    width: int
+    height: int
+    tiles: Dict[Coord, Tile]
+    units: Dict[int, Unit]
+    cities: Dict[int, City]
+    players: Dict[int, Player]
+    current: int = 0
+    turn: int = 1
+    next_id: int = 0
+
+    def gen_id(self) -> int:
+        self.next_id += 1
+        return self.next_id
+
+
+__all__ = [
+    "Coord",
+    "Tile",
+    "Unit",
+    "City",
+    "Player",
+    "State",
+]

--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from random import Random
+from typing import Optional, Tuple
+
+from .. import config
+from . import mapgen
+from .models import City, Coord, Player, State, Tile, Unit
+
+
+class RuleError(Exception):
+    pass
+
+
+def new_game(w: int, h: int, seed: int) -> State:
+    tiles, spawns = mapgen.generate_map(w, h, seed)
+    units_list = mapgen.initial_units(spawns)
+    players = {i: Player(i) for i in range(len(spawns))}
+    state = State(w, h, tiles, {}, {}, players)
+    for u in units_list:
+        u.id = state.gen_id()
+        state.units[u.id] = u
+        reveal(state, u.owner, u.pos)
+    return state
+
+
+def tile_at(state: State, pos: Coord) -> Tile:
+    return state.tiles[pos]
+
+
+def reveal(state: State, owner: int, pos: Coord) -> None:
+    r = config.REVEAL_RADIUS
+    px, py = pos
+    for y in range(py - r, py + r + 1):
+        for x in range(px - r, px + r + 1):
+            if (x, y) in state.tiles:
+                state.tiles[(x, y)].revealed_by.add(owner)
+
+
+def move_unit(state: State, uid: int, dest: Coord) -> None:
+    unit = state.units[uid]
+    tile = tile_at(state, dest)
+    cost = config.MOVE_COST[tile.kind]
+    if cost > unit.moves_left:
+        raise RuleError("not enough moves")
+    # check friendly occupancy
+    for other in state.units.values():
+        if other.pos == dest:
+            if other.owner == unit.owner:
+                raise RuleError("tile occupied")
+            else:  # combat
+                del state.units[other.id]
+                break
+    # city capture
+    for city in list(state.cities.values()):
+        if city.pos == dest and city.owner != unit.owner:
+            if unit.kind != "soldier":
+                raise RuleError("need soldier to capture city")
+            city.owner = unit.owner
+    unit.pos = dest
+    unit.moves_left -= cost
+    reveal(state, unit.owner, dest)
+
+
+def found_city(state: State, uid: int) -> int:
+    unit = state.units[uid]
+    tile = tile_at(state, unit.pos)
+    if tile.kind == "water":
+        raise RuleError("cannot found on water")
+    if unit.owner not in tile.revealed_by:
+        raise RuleError("tile not revealed")
+    cid = state.gen_id()
+    state.cities[cid] = City(cid, unit.owner, unit.pos)
+    del state.units[uid]
+    return cid
+
+
+def buy_unit(state: State, city_id: int, kind: str) -> int:
+    city = state.cities[city_id]
+    player = state.players[city.owner]
+    cost = config.UNIT_STATS[kind]["cost"]
+    if player.prod < cost:
+        raise RuleError("not enough production")
+    # check occupancy
+    for u in state.units.values():
+        if u.pos == city.pos and u.owner != city.owner:
+            raise RuleError("enemy occupying")
+    player.prod -= cost
+    uid = state.gen_id()
+    unit = Unit(uid, city.owner, kind, city.pos, config.UNIT_STATS[kind]["moves"])
+    state.units[uid] = unit
+    reveal(state, unit.owner, unit.pos)
+    return uid
+
+
+def end_turn(state: State, rng: Random) -> None:
+    # yields
+    for city in state.cities.values():
+        player = state.players[city.owner]
+        fx, px = city_yield(state, city.pos)
+        player.food += fx
+        player.prod += px
+    # reset moves
+    for unit in state.units.values():
+        unit.moves_left = config.UNIT_STATS[unit.kind]["moves"]
+    state.current = 1 - state.current
+    state.turn += 1
+
+
+def city_yield(state: State, pos: Coord) -> Tuple[int, int]:
+    x, y = pos
+    food = 0
+    prod = 0
+    for dy in (-1, 0, 1):
+        for dx in (-1, 0, 1):
+            if (x + dx, y + dy) in state.tiles:
+                f, p = config.YIELD[state.tiles[(x + dx, y + dy)].kind]
+                food += f
+                prod += p
+    return food, prod
+
+
+def check_win(state: State) -> Optional[int]:
+    owners = {c.owner for c in state.cities.values()}
+    if len(owners) == 1 and owners:
+        return owners.pop()
+    return None
+
+
+__all__ = [
+    "RuleError",
+    "new_game",
+    "tile_at",
+    "move_unit",
+    "found_city",
+    "buy_unit",
+    "end_turn",
+    "check_win",
+    "reveal",
+]

--- a/game/core/saveio.py
+++ b/game/core/saveio.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .models import City, Player, State, Tile, Unit
+
+
+def save_game(state: State, path: str | Path) -> None:
+    data: Dict[str, Any] = {
+        "size": [state.width, state.height],
+        "current": state.current,
+        "turn": state.turn,
+        "next_id": state.next_id,
+        "tiles": [
+            {"x": t.x, "y": t.y, "kind": t.kind, "revealed": list(t.revealed_by)}
+            for t in state.tiles.values()
+        ],
+        "units": [
+            {
+                "id": u.id,
+                "owner": u.owner,
+                "kind": u.kind,
+                "pos": list(u.pos),
+                "moves_left": u.moves_left,
+            }
+            for u in state.units.values()
+        ],
+        "cities": [
+            {"id": c.id, "owner": c.owner, "pos": list(c.pos)}
+            for c in state.cities.values()
+        ],
+        "players": [
+            {"id": p.id, "food": p.food, "prod": p.prod} for p in state.players.values()
+        ],
+    }
+    Path(path).write_text(json.dumps(data))
+
+
+def load_game(path: str | Path) -> State:
+    data = json.loads(Path(path).read_text())
+    w, h = data["size"]
+    tiles = {
+        (t["x"], t["y"]): Tile(t["x"], t["y"], t["kind"], set(t["revealed"]))
+        for t in data["tiles"]
+    }
+    players = {p["id"]: Player(p["id"], p["food"], p["prod"]) for p in data["players"]}
+    units = {
+        u["id"]: Unit(u["id"], u["owner"], u["kind"], tuple(u["pos"]), u["moves_left"])
+        for u in data["units"]
+    }
+    cities = {
+        c["id"]: City(c["id"], c["owner"], tuple(c["pos"])) for c in data["cities"]
+    }
+    state = State(
+        w,
+        h,
+        tiles,
+        units,
+        cities,
+        players,
+        data["current"],
+        data["turn"],
+        data["next_id"],
+    )
+    return state
+
+
+__all__ = ["save_game", "load_game"]

--- a/game/main.py
+++ b/game/main.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pygame
+
+from .scenes.menu import Menu
+
+
+def main() -> None:
+    pygame.init()
+    Menu().run()
+    pygame.quit()
+
+
+if __name__ == "__main__":
+    main()

--- a/game/scenes/gameplay.py
+++ b/game/scenes/gameplay.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from random import Random
+
+import pygame
+import pygame_gui
+
+from .. import config
+from ..core import ai, rules
+from ..ui import renderer
+from ..ui.hud import Hud
+from ..ui.input import InputHandler
+
+
+class Gameplay:
+    def __init__(self, size: tuple[int, int], seed: int):
+        self.state = rules.new_game(*size, seed)
+        self.rng = Random(seed)
+        w, h = size
+        self.screen_size = (
+            w * config.TILE_SIZE,
+            h * config.TILE_SIZE + config.UI_BAR_H,
+        )
+        self.manager = pygame_gui.UIManager(self.screen_size)
+        self.hud = Hud(self.manager)
+        self.input = InputHandler()
+
+    def run(self) -> None:
+        pygame.display.set_caption("4X Prototype")
+        screen = pygame.display.set_mode(self.screen_size)
+        clock = pygame.time.Clock()
+        running = True
+        while running:
+            time_delta = clock.tick(30) / 1000
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                self.manager.process_events(event)
+                self.input.handle(event, self.state)
+                if (
+                    event.type == pygame.USEREVENT
+                    and event.user_type == pygame_gui.UI_BUTTON_PRESSED
+                ):
+                    if event.ui_element == self.hud.end_btn:
+                        rules.end_turn(self.state, self.rng)
+                        if self.state.current == 1:
+                            ai.ai_take_turn(self.state, self.rng)
+                            rules.end_turn(self.state, self.rng)
+                    elif (
+                        event.ui_element == self.hud.city_btn
+                        and self.input.selected is not None
+                    ):
+                        try:
+                            rules.found_city(self.state, self.input.selected)
+                            self.input.selected = None
+                        except rules.RuleError:
+                            pass
+                    elif event.ui_element == self.hud.scout_btn:
+                        self._buy_unit("scout")
+                    elif event.ui_element == self.hud.soldier_btn:
+                        self._buy_unit("soldier")
+            self.manager.update(time_delta)
+            renderer.draw(self.state, screen, self.state.current)
+            self.manager.draw_ui(screen)
+            pygame.display.flip()
+
+    def _buy_unit(self, kind: str) -> None:
+        for city in self.state.cities.values():
+            if city.owner == self.state.current:
+                try:
+                    rules.buy_unit(self.state, city.id, kind)
+                except rules.RuleError:
+                    pass
+                break
+
+
+__all__ = ["Gameplay"]

--- a/game/scenes/menu.py
+++ b/game/scenes/menu.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import pygame
+import pygame_gui
+
+from .. import config
+from .gameplay import Gameplay
+
+
+class Menu:
+    def __init__(self) -> None:
+        self.size = config.START_SIZE
+        self.seed = 0
+        w, h = self.size
+        screen_size = (w * config.TILE_SIZE, h * config.TILE_SIZE + config.UI_BAR_H)
+        self.manager = pygame_gui.UIManager(screen_size)
+        y = h * config.TILE_SIZE
+        self.new_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(0, y, 100, config.UI_BAR_H), "New Game", self.manager
+        )
+        self.quit_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(110, y, 100, config.UI_BAR_H), "Quit", self.manager
+        )
+        self.screen_size = screen_size
+
+    def run(self) -> None:
+        screen = pygame.display.set_mode(self.screen_size)
+        clock = pygame.time.Clock()
+        running = True
+        while running:
+            time_delta = clock.tick(30) / 1000
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                self.manager.process_events(event)
+                if (
+                    event.type == pygame.USEREVENT
+                    and event.user_type == pygame_gui.UI_BUTTON_PRESSED
+                ):
+                    if event.ui_element == self.new_btn:
+                        Gameplay(self.size, self.seed).run()
+                    elif event.ui_element == self.quit_btn:
+                        running = False
+            self.manager.update(time_delta)
+            screen.fill((0, 0, 0))
+            self.manager.draw_ui(screen)
+            pygame.display.flip()
+
+
+__all__ = ["Menu"]

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pygame
+import pygame_gui
+
+from .. import config
+
+
+class Hud:
+    def __init__(self, manager: pygame_gui.UIManager):
+        y = config.START_SIZE[1] * config.TILE_SIZE
+        self.end_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(0, y, 100, config.UI_BAR_H), "End Turn", manager
+        )
+        self.city_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(110, y, 120, config.UI_BAR_H), "Found City", manager
+        )
+        self.scout_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(240, y, 120, config.UI_BAR_H), "Buy Scout", manager
+        )
+        self.soldier_btn = pygame_gui.elements.UIButton(
+            pygame.Rect(370, y, 120, config.UI_BAR_H), "Buy Soldier", manager
+        )
+
+
+__all__ = ["Hud"]

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import pygame
+
+from .. import config
+from ..core import rules
+from ..core.models import State
+
+
+class InputHandler:
+    def __init__(self) -> None:
+        self.selected: int | None = None
+
+    def handle(self, event: pygame.event.Event, state: State) -> None:
+        if event.type == pygame.MOUSEBUTTONDOWN:
+            x, y = event.pos
+            tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+            if event.button == 1:  # select
+                self.selected = None
+                for u in state.units.values():
+                    if u.pos == tile and u.owner == state.current:
+                        self.selected = u.id
+                        break
+            elif event.button == 3 and self.selected is not None:
+                try:
+                    rules.move_unit(state, self.selected, tile)
+                except rules.RuleError:
+                    pass
+
+
+__all__ = ["InputHandler"]

--- a/game/ui/renderer.py
+++ b/game/ui/renderer.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pygame
+
+from .. import config
+from ..core.models import State
+
+COLORS = {
+    "plains": (80, 200, 120),
+    "forest": (16, 160, 0),
+    "hill": (160, 120, 80),
+    "water": (30, 30, 200),
+    "fog": (0, 0, 0),
+}
+UNIT_COLORS = {0: (0, 0, 0), 1: (200, 0, 0)}
+
+
+def draw(state: State, surface: pygame.Surface, owner: int) -> None:
+    for tile in state.tiles.values():
+        rect = pygame.Rect(
+            tile.x * config.TILE_SIZE,
+            tile.y * config.TILE_SIZE,
+            config.TILE_SIZE,
+            config.TILE_SIZE,
+        )
+        if owner in tile.revealed_by:
+            color = COLORS[tile.kind]
+        else:
+            color = COLORS["fog"]
+        pygame.draw.rect(surface, color, rect)
+    for city in state.cities.values():
+        rect = pygame.Rect(
+            city.pos[0] * config.TILE_SIZE + 8,
+            city.pos[1] * config.TILE_SIZE + 8,
+            16,
+            16,
+        )
+        pygame.draw.rect(surface, UNIT_COLORS[city.owner], rect)
+    for unit in state.units.values():
+        rect = pygame.Rect(
+            unit.pos[0] * config.TILE_SIZE + 4,
+            unit.pos[1] * config.TILE_SIZE + 4,
+            24,
+            24,
+        )
+        pygame.draw.rect(surface, UNIT_COLORS[unit.owner], rect)
+
+
+__all__ = ["draw"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "W", "I"]
+ignore = []
+
+[project]
+name = "codex-4x-game"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pygame>=2.5.0
+pygame_gui>=0.6.9
+pytest
+black
+ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,18 @@
+from random import Random
+
+from game.core import ai, rules
+
+
+def test_ai_moves() -> None:
+    state = rules.new_game(6, 6, seed=1)
+    rng = Random(1)
+    # ensure clear surroundings
+    spawn = (state.width - 2, state.height - 2)
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if (spawn[0] + dx, spawn[1] + dy) in state.tiles:
+                state.tiles[(spawn[0] + dx, spawn[1] + dy)].kind = "plains"
+    ai.ai_take_turn(state, rng)
+    moved = any(u.owner == 1 and u.pos != spawn for u in state.units.values())
+    has_city = any(c.owner == 1 for c in state.cities.values())
+    assert moved or has_city

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,59 @@
+import pytest
+
+from game import config
+from game.core import rules
+from game.core.models import State
+
+
+def setup_state() -> State:
+    state = rules.new_game(4, 4, seed=0)
+    return state
+
+
+def test_move_cost() -> None:
+    state = setup_state()
+    unit = next(iter(state.units.values()))
+    # set destination to water so cost high
+    dest = (unit.pos[0] + 1, unit.pos[1])
+    state.tiles[dest].kind = "forest"
+    unit.moves_left = 1
+    with pytest.raises(rules.RuleError):
+        rules.move_unit(state, unit.id, dest)
+
+
+def test_reveal_radius() -> None:
+    state = setup_state()
+    unit = next(iter(state.units.values()))
+    dest = (unit.pos[0] + 1, unit.pos[1])
+    state.tiles[dest].kind = "plains"
+    rules.move_unit(state, unit.id, dest)
+    px, py = dest
+    for dy in range(-config.REVEAL_RADIUS, config.REVEAL_RADIUS + 1):
+        for dx in range(-config.REVEAL_RADIUS, config.REVEAL_RADIUS + 1):
+            tile = (px + dx, py + dy)
+            if tile in state.tiles:
+                assert unit.owner in state.tiles[tile].revealed_by
+
+
+def test_found_city_validation() -> None:
+    state = setup_state()
+    unit = next(iter(state.units.values()))
+    state.tiles[unit.pos].kind = "water"
+    with pytest.raises(rules.RuleError):
+        rules.found_city(state, unit.id)
+
+
+def test_buy_unit_cost() -> None:
+    state = setup_state()
+    unit = next(iter(state.units.values()))
+    cid = rules.found_city(state, unit.id)
+    state.players[0].prod = config.UNIT_STATS["scout"]["cost"]
+    rules.buy_unit(state, cid, "scout")
+    assert state.players[0].prod == 0
+
+
+def test_win_condition() -> None:
+    state = setup_state()
+    unit = next(iter(state.units.values()))
+    rules.found_city(state, unit.id)
+    assert rules.check_win(state) is not None

--- a/tests/test_saveio.py
+++ b/tests/test_saveio.py
@@ -1,0 +1,19 @@
+from tempfile import TemporaryDirectory
+
+from game import config
+from game.core import rules, saveio
+
+
+def test_roundtrip() -> None:
+    state = rules.new_game(5, 5, seed=2)
+    unit = next(iter(state.units.values()))
+    cid = rules.found_city(state, unit.id)
+    state.players[0].prod = config.UNIT_STATS["scout"]["cost"]
+    rules.buy_unit(state, cid, "scout")
+    with TemporaryDirectory() as d:
+        path = f"{d}/save.json"
+        saveio.save_game(state, path)
+        loaded = saveio.load_game(path)
+    assert loaded.width == state.width
+    assert len(loaded.units) == len(state.units)
+    assert len(loaded.cities) == len(state.cities)


### PR DESCRIPTION
## Summary
- implement datamodels, rules engine, AI, save/load, and pygame scenes for a basic 4X game
- add deterministic map generation, HUD, and input handling
- provide pytest, ruff, and black configuration

## Testing
- `ruff check .`
- `python -m black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75ca56cd48328a4ae60807b6f8e22