### PR TITLE
Add pygame-based 4X game prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.ruff_cache/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
 # codex-4x-game
+
+Prototype turn-based 4X game built with pygame and pygame_gui.
+
+## Requirements
+- Python 3.11
+- pygame >= 2.5.0
+- pygame_gui >= 0.6.9
+
+Install dependencies:
+```bash
+pip install -r requirements.txt
+```
+
+## Running
+```bash
+python -m game.main
+```
+
+## Tests
+```bash
+pytest -q
+```
+
+## Lint and Format
+```bash
+ruff check .
+black .
+```

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -1,0 +1,1 @@
+"""4X game package."""

--- a/game/config.py
+++ b/game/config.py
@@ -1,0 +1,7 @@
+TILE_SIZE = 32
+UI_BAR_H = 64
+MOVE_COST = {"plains": 1, "forest": 2, "hill": 2, "water": 999}
+YIELD = {"plains": (1, 1), "forest": (0, 2), "hill": (0, 2), "water": (0, 0)}
+UNIT_STATS = {"scout": {"moves": 3, "cost": 3}, "soldier": {"moves": 2, "cost": 4}}
+REVEAL_RADIUS = 3
+START_SIZE = (20, 12)

--- a/game/core/ai.py
+++ b/game/core/ai.py
@@ -1,0 +1,35 @@
+"""Very simple AI for expansion/attack."""
+
+from __future__ import annotations
+
+from random import Random
+from typing import List
+
+from .models import Coord, State
+from .rules import RuleError, end_turn, found_city, move_unit
+
+DIRS: List[Coord] = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+
+
+def ai_turn(state: State, rng: Random) -> None:
+    """Perform a simple AI turn."""
+    for unit in list(state.units.values()):
+        if unit.owner != state.current_player:
+            continue
+        for _ in range(4):
+            dx, dy = rng.choice(DIRS)
+            dest = (unit.pos[0] + dx, unit.pos[1] + dy)
+            try:
+                move_unit(state, unit.id, dest)
+                return
+            except RuleError:
+                continue
+        try:
+            found_city(state, unit.id)
+            return
+        except RuleError:
+            continue
+    end_turn(state)
+
+
+__all__ = ["ai_turn"]

--- a/game/core/mapgen.py
+++ b/game/core/mapgen.py
@@ -1,0 +1,49 @@
+"""Procedural map generation."""
+
+from __future__ import annotations
+
+from random import Random
+from typing import List, Tuple
+
+from .. import config
+from .models import Tile, Unit
+
+
+def generate_map(w: int, h: int, seed: int) -> Tuple[List[Tile], List[Tuple[int, int]]]:
+    rng = Random(seed)
+    tiles: List[Tile] = []
+    for y in range(h):
+        for x in range(w):
+            if rng.random() < 0.1:
+                kind = "water"
+            elif rng.random() < 0.2:
+                kind = "forest"
+            elif rng.random() < 0.3:
+                kind = "hill"
+            else:
+                kind = "plains"
+            tiles.append(Tile(x=x, y=y, kind=kind))
+    # spawn points at opposite corners on land
+    spawns = [(1, 1), (w - 2, h - 2)]
+    for sx, sy in spawns:
+        idx = sy * w + sx
+        tiles[idx].kind = "plains"
+    return tiles, spawns
+
+
+def initial_units(spawns: List[Tuple[int, int]]) -> List[Unit]:
+    units: List[Unit] = []
+    for i, pos in enumerate(spawns):
+        units.append(
+            Unit(
+                id=i + 1,
+                owner=i,
+                kind="scout",
+                pos=pos,
+                moves_left=config.UNIT_STATS["scout"]["moves"],
+            )
+        )
+    return units
+
+
+__all__ = ["generate_map", "initial_units"]

--- a/game/core/models.py
+++ b/game/core/models.py
@@ -1,0 +1,76 @@
+"""Data models for the 4X game."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set, Tuple
+
+Coord = Tuple[int, int]
+
+
+@dataclass
+class Tile:
+    x: int
+    y: int
+    kind: str  # 'plains' | 'forest' | 'hill' | 'water'
+    revealed_by: Set[int] = field(default_factory=set)
+
+
+@dataclass
+class Unit:
+    id: int
+    owner: int  # 0 human, 1 ai
+    kind: str  # 'scout' | 'soldier'
+    pos: Coord
+    moves_left: int
+
+
+@dataclass
+class City:
+    id: int
+    owner: int
+    pos: Coord
+
+
+@dataclass
+class Player:
+    id: int
+    food: int = 0
+    prod: int = 0
+
+
+@dataclass
+class State:
+    width: int
+    height: int
+    tiles: List[Tile]
+    units: Dict[int, Unit]
+    cities: Dict[int, City]
+    players: Dict[int, Player]
+    current_player: int = 0
+    turn: int = 1
+    next_unit_id: int = 1
+    next_city_id: int = 1
+
+    def tile_at(self, coord: Coord) -> Tile:
+        x, y = coord
+        return self.tiles[y * self.width + x]
+
+    def units_at(self, coord: Coord) -> List[Unit]:
+        return [u for u in self.units.values() if u.pos == coord]
+
+    def city_at(self, coord: Coord) -> Optional[City]:
+        for city in self.cities.values():
+            if city.pos == coord:
+                return city
+        return None
+
+
+__all__ = [
+    "Coord",
+    "Tile",
+    "Unit",
+    "City",
+    "Player",
+    "State",
+]

--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -1,0 +1,119 @@
+"""Game rules and turn engine."""
+
+from __future__ import annotations
+
+from .. import config
+from .models import City, Coord, State, Unit
+
+
+class RuleError(Exception):
+    """Raised when an action is invalid."""
+
+
+def in_bounds(state: State, coord: Coord) -> bool:
+    x, y = coord
+    return 0 <= x < state.width and 0 <= y < state.height
+
+
+def distance(a: Coord, b: Coord) -> int:
+    return abs(a[0] - b[0]) + abs(a[1] - b[1])
+
+
+def reveal(state: State, unit: Unit) -> None:
+    for x in range(state.width):
+        for y in range(state.height):
+            if distance((x, y), unit.pos) <= config.REVEAL_RADIUS:
+                state.tile_at((x, y)).revealed_by.add(unit.owner)
+
+
+def move_unit(state: State, unit_id: int, dest: Coord) -> None:
+    unit = state.units[unit_id]
+    if unit.owner != state.current_player:
+        raise RuleError("not your unit")
+    if not in_bounds(state, dest):
+        raise RuleError("out of bounds")
+    tile = state.tile_at(dest)
+    cost = config.MOVE_COST[tile.kind]
+    if cost > unit.moves_left:
+        raise RuleError("not enough moves")
+    unit.pos = dest
+    unit.moves_left -= cost
+    reveal(state, unit)
+    for other in list(state.units.values()):
+        if other is unit:
+            continue
+        if other.pos == dest and other.owner != unit.owner:
+            del state.units[other.id]
+    city = state.city_at(dest)
+    if city and city.owner != unit.owner and unit.kind == "soldier":
+        city.owner = unit.owner
+
+
+def end_turn(state: State) -> None:
+    for city in state.cities.values():
+        food, prod = config.YIELD[state.tile_at(city.pos).kind]
+        player = state.players[city.owner]
+        player.food += food
+        player.prod += prod
+    state.current_player = 1 - state.current_player
+    state.turn += 1
+    for unit in state.units.values():
+        if unit.owner == state.current_player:
+            unit.moves_left = config.UNIT_STATS[unit.kind]["moves"]
+
+
+def found_city(state: State, unit_id: int) -> City:
+    unit = state.units[unit_id]
+    tile = state.tile_at(unit.pos)
+    if tile.kind == "water":
+        raise RuleError("cannot found on water")
+    if state.city_at(unit.pos):
+        raise RuleError("city exists")
+    city = City(id=state.next_city_id, owner=unit.owner, pos=unit.pos)
+    state.cities[city.id] = city
+    state.next_city_id += 1
+    del state.units[unit.id]
+    return city
+
+
+def buy_unit(state: State, city_id: int, kind: str) -> Unit:
+    city = state.cities[city_id]
+    if city.owner != state.current_player:
+        raise RuleError("not your city")
+    cost = config.UNIT_STATS[kind]["cost"]
+    player = state.players[city.owner]
+    if player.prod < cost:
+        raise RuleError("not enough production")
+    if state.units_at(city.pos):
+        raise RuleError("tile occupied")
+    player.prod -= cost
+    unit = Unit(
+        id=state.next_unit_id,
+        owner=city.owner,
+        kind=kind,
+        pos=city.pos,
+        moves_left=config.UNIT_STATS[kind]["moves"],
+    )
+    state.units[unit.id] = unit
+    state.next_unit_id += 1
+    reveal(state, unit)
+    return unit
+
+
+def check_win(state: State) -> int | None:
+    owners = {city.owner for city in state.cities.values()}
+    if 0 not in owners:
+        return 1
+    if 1 not in owners:
+        return 0
+    return None
+
+
+__all__ = [
+    "RuleError",
+    "move_unit",
+    "end_turn",
+    "found_city",
+    "buy_unit",
+    "check_win",
+]

--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -101,6 +101,9 @@ def buy_unit(state: State, city_id: int, kind: str) -> Unit:
 
 
 def check_win(state: State) -> int | None:
+    """Return winning player id if a side has no cities."""
+    if not state.cities:
+        return None
     owners = {city.owner for city in state.cities.values()}
     if 0 not in owners:
         return 1

--- a/game/core/saveio.py
+++ b/game/core/saveio.py
@@ -1,0 +1,88 @@
+"""JSON save/load for game state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .models import City, Player, State, Tile, Unit
+
+
+def state_to_dict(state: State) -> Dict[str, Any]:
+    return {
+        "width": state.width,
+        "height": state.height,
+        "tiles": [
+            {"x": t.x, "y": t.y, "kind": t.kind, "revealed_by": list(t.revealed_by)}
+            for t in state.tiles
+        ],
+        "units": {
+            uid: {
+                "id": u.id,
+                "owner": u.owner,
+                "kind": u.kind,
+                "pos": list(u.pos),
+                "moves_left": u.moves_left,
+            }
+            for uid, u in state.units.items()
+        },
+        "cities": {
+            cid: {"id": c.id, "owner": c.owner, "pos": list(c.pos)}
+            for cid, c in state.cities.items()
+        },
+        "players": {
+            pid: {"id": p.id, "food": p.food, "prod": p.prod}
+            for pid, p in state.players.items()
+        },
+        "current_player": state.current_player,
+        "turn": state.turn,
+        "next_unit_id": state.next_unit_id,
+        "next_city_id": state.next_city_id,
+    }
+
+
+def dict_to_state(data: Dict[str, Any]) -> State:
+    tiles = [
+        Tile(x=t["x"], y=t["y"], kind=t["kind"], revealed_by=set(t["revealed_by"]))
+        for t in data["tiles"]
+    ]
+    units = {
+        int(uid): Unit(
+            id=u["id"],
+            owner=u["owner"],
+            kind=u["kind"],
+            pos=tuple(u["pos"]),
+            moves_left=u["moves_left"],
+        )
+        for uid, u in data["units"].items()
+    }
+    cities = {
+        int(cid): City(id=c["id"], owner=c["owner"], pos=tuple(c["pos"]))
+        for cid, c in data["cities"].items()
+    }
+    players = {int(pid): Player(**p) for pid, p in data["players"].items()}
+    return State(
+        width=data["width"],
+        height=data["height"],
+        tiles=tiles,
+        units=units,
+        cities=cities,
+        players=players,
+        current_player=data["current_player"],
+        turn=data["turn"],
+        next_unit_id=data["next_unit_id"],
+        next_city_id=data["next_city_id"],
+    )
+
+
+def save_game(state: State, path: str | Path) -> None:
+    Path(path).write_text(json.dumps(state_to_dict(state)))
+
+
+def load_game(path: str | Path) -> State:
+    data = json.loads(Path(path).read_text())
+    return dict_to_state(data)
+
+
+__all__ = ["save_game", "load_game", "state_to_dict", "dict_to_state"]

--- a/game/main.py
+++ b/game/main.py
@@ -1,0 +1,19 @@
+"""Entry point for the 4X game."""
+
+from __future__ import annotations
+
+import pygame
+
+from .scenes.menu import Menu
+
+
+def main() -> None:
+    pygame.init()
+    size = (640, 480)
+    pygame.display.set_mode(size)
+    Menu().run()
+    pygame.quit()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/game/scenes/gameplay.py
+++ b/game/scenes/gameplay.py
@@ -1,0 +1,70 @@
+"""Gameplay scene."""
+
+from __future__ import annotations
+
+from random import Random
+
+import pygame
+
+from .. import config
+from ..core import ai, mapgen
+from ..core.models import Player, State
+from ..core.rules import check_win
+from ..ui.hud import HUD
+from ..ui.input import InputHandler
+from ..ui.renderer import draw
+
+
+class Gameplay:
+    def __init__(self, size: tuple[int, int], seed: int) -> None:
+        tiles, spawns = mapgen.generate_map(*size, seed)
+        units = {u.id: u for u in mapgen.initial_units(spawns)}
+        players = {0: Player(0), 1: Player(1)}
+        self.state = State(
+            width=size[0],
+            height=size[1],
+            tiles=tiles,
+            units=units,
+            cities={},
+            players=players,
+        )
+        for unit in self.state.units.values():
+            unit.moves_left = config.UNIT_STATS[unit.kind]["moves"]
+        self.screen = pygame.display.get_surface()
+        self.hud = HUD(
+            pygame.Rect(
+                0,
+                size[1] * config.TILE_SIZE,
+                size[0] * config.TILE_SIZE,
+                config.UI_BAR_H,
+            )
+        )
+        self.input = InputHandler(self.hud)
+        for unit in self.state.units.values():
+            for x in range(self.state.width):
+                for y in range(self.state.height):
+                    if (
+                        abs(unit.pos[0] - x) + abs(unit.pos[1] - y)
+                        <= config.REVEAL_RADIUS
+                    ):
+                        self.state.tile_at((x, y)).revealed_by.add(unit.owner)
+
+    def run(self) -> None:
+        clock = pygame.time.Clock()
+        rng = Random()
+        running = True
+        while running:
+            time_delta = clock.tick(30) / 1000.0
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                else:
+                    self.input.handle_event(event, self.state)
+            if self.state.current_player == 1:
+                ai.ai_turn(self.state, rng)
+            self.hud.update(time_delta, self.state)
+            draw(self.state, self.screen)
+            self.hud.draw(self.screen)
+            pygame.display.flip()
+            if check_win(self.state) is not None:
+                running = False

--- a/game/scenes/menu.py
+++ b/game/scenes/menu.py
@@ -1,0 +1,48 @@
+"""Menu scene."""
+
+from __future__ import annotations
+
+import pygame
+import pygame_gui
+
+from .. import config
+from .gameplay import Gameplay
+
+
+class Menu:
+    def __init__(self) -> None:
+        self.manager = pygame_gui.UIManager((640, 480))
+        self.new = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(270, 150, 100, 50),
+            text="New Game",
+            manager=self.manager,
+        )
+        self.quit = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(270, 220, 100, 50),
+            text="Quit",
+            manager=self.manager,
+        )
+
+    def run(self) -> None:
+        clock = pygame.time.Clock()
+        running = True
+        while running:
+            time_delta = clock.tick(30) / 1000.0
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    running = False
+                elif (
+                    event.type == pygame.USEREVENT
+                    and event.user_type == pygame_gui.UI_BUTTON_PRESSED
+                ):
+                    if event.ui_element == self.new:
+                        game = Gameplay(config.START_SIZE, seed=1)
+                        game.run()
+                    elif event.ui_element == self.quit:
+                        running = False
+                self.manager.process_events(event)
+            self.manager.update(time_delta)
+            surface = pygame.display.get_surface()
+            surface.fill((0, 0, 0))
+            self.manager.draw_ui(surface)
+            pygame.display.flip()

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -1,0 +1,51 @@
+"""HUD with pygame_gui buttons."""
+
+from __future__ import annotations
+
+import pygame
+import pygame_gui
+
+from ..core.models import State
+
+
+class HUD:
+    def __init__(self, rect: pygame.Rect) -> None:
+        self.manager = pygame_gui.UIManager(rect.size)
+        self.end_turn = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(10, 10, 80, 40),
+            text="End Turn",
+            manager=self.manager,
+        )
+        self.found_city = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(100, 10, 100, 40),
+            text="Found City",
+            manager=self.manager,
+        )
+        self.buy_scout = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(210, 10, 100, 40),
+            text="Buy Scout",
+            manager=self.manager,
+        )
+        self.buy_soldier = pygame_gui.elements.UIButton(
+            relative_rect=pygame.Rect(320, 10, 100, 40),
+            text="Buy Soldier",
+            manager=self.manager,
+        )
+        self.info = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(430, 10, 200, 40),
+            text="",
+            manager=self.manager,
+        )
+
+    def process_event(self, event: pygame.event.Event) -> None:
+        self.manager.process_events(event)
+
+    def update(self, time_delta: float, state: State) -> None:
+        self.info.set_text(
+            f"Turn {state.turn} Player {state.current_player} "
+            f"F:{state.players[0].food} P:{state.players[0].prod}"
+        )
+        self.manager.update(time_delta)
+
+    def draw(self, surface: pygame.Surface) -> None:
+        self.manager.draw_ui(surface)

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -1,0 +1,64 @@
+"""Translate input events into game actions."""
+
+from __future__ import annotations
+
+import pygame
+import pygame_gui
+
+from .. import config
+from ..core import rules
+from ..core.models import State
+from .hud import HUD
+
+
+class InputHandler:
+    def __init__(self, hud: HUD) -> None:
+        self.hud = hud
+        self.selected: int | None = None
+
+    def handle_event(self, event: pygame.event.Event, state: State) -> None:
+        self.hud.process_event(event)
+        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+            x, y = event.pos
+            tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+            for unit in state.units.values():
+                if unit.pos == tile and unit.owner == state.current_player:
+                    self.selected = unit.id
+                    break
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
+            if self.selected is not None:
+                x, y = event.pos
+                dest = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+                try:
+                    rules.move_unit(state, self.selected, dest)
+                except rules.RuleError:
+                    pass
+        elif event.type == pygame.USEREVENT:
+            if event.user_type == pygame_gui.UI_BUTTON_PRESSED:
+                if event.ui_element == self.hud.end_turn:
+                    rules.end_turn(state)
+                elif (
+                    event.ui_element == self.hud.found_city
+                    and self.selected is not None
+                ):
+                    try:
+                        rules.found_city(state, self.selected)
+                        self.selected = None
+                    except rules.RuleError:
+                        pass
+                elif event.ui_element == self.hud.buy_scout:
+                    for city in state.cities.values():
+                        if city.owner == state.current_player:
+                            try:
+                                rules.buy_unit(state, city.id, "scout")
+                            except rules.RuleError:
+                                pass
+                            break
+                elif event.ui_element == self.hud.buy_soldier:
+                    for city in state.cities.values():
+                        if city.owner == state.current_player:
+                            try:
+                                rules.buy_unit(state, city.id, "soldier")
+                            except rules.RuleError:
+                                pass
+                            break

--- a/game/ui/renderer.py
+++ b/game/ui/renderer.py
@@ -1,0 +1,35 @@
+"""Rendering utilities."""
+
+from __future__ import annotations
+
+import pygame
+
+from .. import config
+from ..core.models import State
+
+COLORS = {
+    "plains": (200, 200, 150),
+    "forest": (34, 139, 34),
+    "hill": (139, 137, 137),
+    "water": (65, 105, 225),
+    "fog": (0, 0, 0),
+    "city": (255, 215, 0),
+    "scout": (255, 255, 255),
+    "soldier": (255, 0, 0),
+}
+
+
+def draw(state: State, surface: pygame.Surface) -> None:
+    ts = config.TILE_SIZE
+    for tile in state.tiles:
+        rect = pygame.Rect(tile.x * ts, tile.y * ts, ts, ts)
+        color = COLORS[tile.kind]
+        surface.fill(color, rect)
+        if state.current_player not in tile.revealed_by:
+            surface.fill(COLORS["fog"], rect)
+    for city in state.cities.values():
+        rect = pygame.Rect(city.pos[0] * ts, city.pos[1] * ts, ts, ts)
+        surface.fill(COLORS["city"], rect)
+    for unit in state.units.values():
+        rect = pygame.Rect(unit.pos[0] * ts + 8, unit.pos[1] * ts + 8, ts - 16, ts - 16)
+        surface.fill(COLORS[unit.kind], rect)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "codex-4x-game"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[tool.black]
+line-length = 88
+
+[tool.ruff]
+line-length = 88
+select = ["E", "F", "I", "B"]
+
+[tool.ruff.per-file-ignores]
+"tests/*" = ["S101"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pygame-ce>=2.5.3
+pygame_gui>=0.6.9
+pytest
+black
+ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -1,0 +1,24 @@
+from random import Random
+
+from game.core import ai, mapgen
+from game.core.models import Player, State
+
+
+def make_state() -> State:
+    tiles, spawns = mapgen.generate_map(5, 5, seed=2)
+    units = {u.id: u for u in mapgen.initial_units(spawns)}
+    players = {0: Player(0), 1: Player(1)}
+    state = State(5, 5, tiles, units, {}, players)
+    state.current_player = 1
+    return state
+
+
+def test_ai_expands():
+    state = make_state()
+    rng = Random(0)
+    for _ in range(5):
+        ai.ai_turn(state, rng)
+    assert state.cities or any(
+        u.owner == 1 and u.pos != (state.width - 2, state.height - 2)
+        for u in state.units.values()
+    )

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,42 @@
+from game import config
+from game.core import mapgen, rules
+from game.core.models import Player, State
+
+
+def make_state() -> State:
+    tiles, spawns = mapgen.generate_map(5, 5, seed=1)
+    units = {u.id: u for u in mapgen.initial_units(spawns)}
+    players = {0: Player(0), 1: Player(1)}
+    state = State(5, 5, tiles, units, {}, players)
+    return state
+
+
+def test_movement_cost_and_fog():
+    state = make_state()
+    uid = next(iter(state.units))
+    dest = (state.units[uid].pos[0] + 1, state.units[uid].pos[1])
+    rules.move_unit(state, uid, dest)
+    assert state.units[uid].moves_left < config.UNIT_STATS["scout"]["moves"]
+    tile = state.tile_at(dest)
+    assert state.current_player in tile.revealed_by
+
+
+def test_found_city_and_buy_unit():
+    state = make_state()
+    uid = next(iter(state.units))
+    state.units[uid].pos = (2, 2)
+    rules.found_city(state, uid)
+    cid = next(iter(state.cities))
+    state.players[0].prod = 10
+    rules.buy_unit(state, cid, "soldier")
+    assert any(u.kind == "soldier" for u in state.units.values())
+
+
+def test_win_condition():
+    state = make_state()
+    uid = next(iter(state.units))
+    state.units[uid].pos = (2, 2)
+    rules.found_city(state, uid)
+    cid = next(iter(state.cities))
+    state.cities[cid].owner = 1
+    assert rules.check_win(state) == 1

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -40,3 +40,8 @@ def test_win_condition():
     cid = next(iter(state.cities))
     state.cities[cid].owner = 1
     assert rules.check_win(state) == 1
+
+
+def test_no_win_without_cities():
+    state = make_state()
+    assert rules.check_win(state) is None

--- a/tests/test_saveio.py
+++ b/tests/test_saveio.py
@@ -1,4 +1,5 @@
 import tempfile
+
 from game.core import mapgen, saveio
 from game.core.models import Player, State
 

--- a/tests/test_saveio.py
+++ b/tests/test_saveio.py
@@ -1,0 +1,20 @@
+import tempfile
+from game.core import mapgen, saveio
+from game.core.models import Player, State
+
+
+def make_state() -> State:
+    tiles, spawns = mapgen.generate_map(5, 5, seed=3)
+    units = {u.id: u for u in mapgen.initial_units(spawns)}
+    players = {0: Player(0), 1: Player(1)}
+    state = State(5, 5, tiles, units, {}, players)
+    return state
+
+
+def test_round_trip():
+    state = make_state()
+    with tempfile.TemporaryDirectory() as td:
+        path = f"{td}/save.json"
+        saveio.save_game(state, path)
+        loaded = saveio.load_game(path)
+    assert saveio.state_to_dict(state) == saveio.state_to_dict(loaded)


### PR DESCRIPTION
## Summary
- scaffold a minimal 4X strategy prototype with pygame-ce and pygame_gui
- implement core rules, map generation, save/load, UI scenes, and simple AI
- add tests, formatting config, and dependency pinning

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7797fb0e0832893118cbfb4890346