### PR TITLE
feat: highlight unit selection and hover context

### DIFF
--- a/game/scenes/gameplay.py
+++ b/game/scenes/gameplay.py
@@ -63,7 +63,7 @@ class Gameplay:
             if self.state.current_player == 1:
                 ai.ai_turn(self.state, rng)
             self.hud.update(time_delta, self.state)
-            draw(self.state, self.screen)
+            draw(self.state, self.screen, self.input.selected)
             self.hud.draw(self.screen)
             pygame.display.flip()
             if check_win(self.state) is not None:

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -36,6 +36,11 @@ class HUD:
             text="",
             manager=self.manager,
         )
+        self.context = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(rect.width - 210, 10, 200, 40),
+            text="",
+            manager=self.manager,
+        )
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)
@@ -49,3 +54,7 @@ class HUD:
 
     def draw(self, surface: pygame.Surface) -> None:
         self.manager.draw_ui(surface)
+
+    def set_context(self, text: str) -> None:
+        """Update the context info label."""
+        self.context.set_text(text)

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -39,7 +39,9 @@ class HUD:
             manager=self.manager,
         )
         self.context = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(rect.width - 210, 10, 200, 40),
+            relative_rect=pygame.Rect(
+                rect.width - 210, rect.height - 50, 200, 40
+            ),
             text="",
             manager=self.manager,
         )

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -10,6 +10,8 @@ from ..core.models import State
 
 class HUD:
     def __init__(self, rect: pygame.Rect) -> None:
+        self.rect = rect
+        self.surface = pygame.Surface(rect.size, pygame.SRCALPHA)
         self.manager = pygame_gui.UIManager(rect.size)
         self.end_turn = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(10, 10, 80, 40),
@@ -53,7 +55,9 @@ class HUD:
         self.manager.update(time_delta)
 
     def draw(self, surface: pygame.Surface) -> None:
-        self.manager.draw_ui(surface)
+        self.surface.fill((0, 0, 0, 0))
+        self.manager.draw_ui(self.surface)
+        surface.blit(self.surface, self.rect.topleft)
 
     def set_context(self, text: str) -> None:
         """Update the context info label."""

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -18,7 +18,27 @@ class InputHandler:
 
     def handle_event(self, event: pygame.event.Event, state: State) -> None:
         self.hud.process_event(event)
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if event.type == pygame.MOUSEMOTION:
+            x, y = event.pos
+            tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+            context = ""
+            if 0 <= tile[0] < state.width and 0 <= tile[1] < state.height:
+                for unit in state.units.values():
+                    if unit.pos == tile:
+                        context = f"{unit.kind.title()} (Player {unit.owner})"
+                        break
+                else:
+                    for city in state.cities.values():
+                        if city.pos == tile:
+                            context = f"City (Player {city.owner})"
+                            break
+                    else:
+                        tile_obj = state.tile_at(tile)
+                        if state.current_player in tile_obj.revealed_by:
+                            food, prod = config.YIELD[tile_obj.kind]
+                            context = f"{tile_obj.kind.title()} F{food} P{prod}"
+            self.hud.set_context(context)
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             x, y = event.pos
             tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
             for unit in state.units.values():

--- a/game/ui/renderer.py
+++ b/game/ui/renderer.py
@@ -19,7 +19,15 @@ COLORS = {
 }
 
 
-def draw(state: State, surface: pygame.Surface) -> None:
+def draw(state: State, surface: pygame.Surface, selected: int | None = None) -> None:
+    """Draw the current game state.
+
+    Args:
+        state: Current game state.
+        surface: Surface to draw on.
+        selected: Optional ID of the selected unit to highlight.
+    """
+
     ts = config.TILE_SIZE
     for tile in state.tiles:
         rect = pygame.Rect(tile.x * ts, tile.y * ts, ts, ts)
@@ -33,3 +41,6 @@ def draw(state: State, surface: pygame.Surface) -> None:
     for unit in state.units.values():
         rect = pygame.Rect(unit.pos[0] * ts + 8, unit.pos[1] * ts + 8, ts - 16, ts - 16)
         surface.fill(COLORS[unit.kind], rect)
+        if selected is not None and unit.id == selected:
+            sel_rect = pygame.Rect(unit.pos[0] * ts, unit.pos[1] * ts, ts, ts)
+            pygame.draw.rect(surface, (255, 255, 0), sel_rect, 3)


### PR DESCRIPTION
## Summary
- highlight selected unit during gameplay
- show context information in HUD when hovering over tiles, units, or cities

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7e1d9f00c8328a8390ae7885fa9d6