### PR TITLE
Add map hover information to HUD

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -31,11 +31,21 @@ class HUD:
             text="Buy Soldier",
             manager=self.manager,
         )
+        remaining = rect.width - 430
+        info_width = max((remaining // 2) - 5, 50)
+        hover_x = 430 + info_width + 10
+        hover_width = rect.width - hover_x - 10
         self.info = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(430, 10, 200, 40),
+            relative_rect=pygame.Rect(430, 10, info_width, 40),
             text="",
             manager=self.manager,
         )
+        self.hover_label = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(hover_x, 10, hover_width, 40),
+            text="",
+            manager=self.manager,
+        )
+        self.hover_text: str = ""
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)
@@ -45,7 +55,12 @@ class HUD:
             f"Turn {state.turn} Player {state.current_player} "
             f"F:{state.players[0].food} P:{state.players[0].prod}"
         )
+        self.hover_label.set_text(self.hover_text)
         self.manager.update(time_delta)
+
+    def set_hover(self, text: str) -> None:
+        self.hover_text = text
+        self.hover_label.set_text(text)
 
     def draw(self, surface: pygame.Surface) -> None:
         self.manager.draw_ui(surface)

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -34,6 +34,32 @@ class InputHandler:
                 self.hud.found_city.enable()
             else:
                 self.hud.found_city.disable()
+        elif event.type == pygame.MOUSEMOTION:
+            x, y = event.pos
+            if (
+                x < 0
+                or y < 0
+                or x >= state.width * config.TILE_SIZE
+                or y >= state.height * config.TILE_SIZE
+            ):
+                self.hud.set_hover("")
+                return
+            coord = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+            tile = state.tile_at(coord)
+            if state.current_player not in tile.revealed_by:
+                self.hud.set_hover("")
+                return
+            units = state.units_at(coord)
+            city = state.city_at(coord)
+            if units:
+                unit = units[0]
+                text = f"{unit.kind.title()} Owner {unit.owner}"
+            elif city:
+                text = f"City Owner {city.owner}"
+            else:
+                food, prod = config.YIELD[tile.kind]
+                text = f"{tile.kind.title()} F:{food} P:{prod}"
+            self.hud.set_hover(text)
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
             if self.selected is not None:
                 x, y = event.pos


### PR DESCRIPTION
## Summary
- Show tile/unit/city details in a new HUD hover label
- Update hover text based on mouse movement across the map

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7eb83a058832891c67f6f9fb72925