### PR TITLE
Position hover label at HUD bottom-right

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -36,6 +36,14 @@ class HUD:
             text="",
             manager=self.manager,
         )
+        hover_width = 200
+        self.hover_label = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(
+                rect.width - hover_width - 10, rect.height - 50, hover_width, 40
+            ),
+            text="",
+            manager=self.manager,
+        )
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)


### PR DESCRIPTION
## Summary
- Anchor HUD hover label to bottom-right corner for consistent placement

## Testing
- `ruff check game/ui/hud.py`
- `black game/ui/hud.py`
- `pytest -q` *(fails: RuleError: cannot found on water in test_win_condition)*

------
https://chatgpt.com/codex/tasks/task_e_68a7edccb1a083289a1a8eae1e7eafea