### PR TITLE
Guard HUD clicks from tile selection

### DIFF
--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -21,19 +21,20 @@ class InputHandler:
         self.hud.process_event(event)
         if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             x, y = event.pos
-            tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
-            self.selected = None
-            for unit in state.units.values():
-                if unit.pos == tile and unit.owner == state.current_player:
-                    self.selected = unit.id
-                    break
-            if (
-                self.selected is not None
-                and state.units[self.selected].kind == "settler"
-            ):
-                self.hud.found_city.enable()
-            else:
-                self.hud.found_city.disable()
+            if y >= config.UI_BAR_H:
+                tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+                self.selected = None
+                for unit in state.units.values():
+                    if unit.pos == tile and unit.owner == state.current_player:
+                        self.selected = unit.id
+                        break
+                if (
+                    self.selected is not None
+                    and state.units[self.selected].kind == "settler"
+                ):
+                    self.hud.found_city.enable()
+                else:
+                    self.hud.found_city.disable()
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
             if self.selected is not None:
                 x, y = event.pos

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -46,3 +46,13 @@ def test_win_condition():
 def test_no_win_without_cities():
     state = make_state()
     assert rules.check_win(state) is None
+
+
+def test_found_city_on_start_tile():
+    state = make_state()
+    uid = next(uid for uid, u in state.units.items() if u.kind == "settler")
+    start = state.units[uid].pos
+    assert state.tile_at(start).kind == "plains"
+    rules.found_city(state, uid)
+    assert any(c.pos == start for c in state.cities.values())
+    assert uid not in state.units


### PR DESCRIPTION
## Summary
- ignore HUD clicks when selecting tiles so settler remains selected
- add regression test for founding a city on the spawn tile

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7ed9ebac4832882815b001195b69a