### PR TITLE
Disable End Turn until first city is founded

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -36,6 +36,12 @@ class HUD:
             text="",
             manager=self.manager,
         )
+        self.hint = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(10, 50, 300, 20),
+            text="",
+            manager=self.manager,
+        )
+        self.hint.hide()
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)
@@ -49,3 +55,10 @@ class HUD:
 
     def draw(self, surface: pygame.Surface) -> None:
         self.manager.draw_ui(surface)
+
+    def show_hint(self, text: str) -> None:
+        self.hint.set_text(text)
+        self.hint.show()
+
+    def hide_hint(self) -> None:
+        self.hint.hide()

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -16,6 +16,8 @@ class InputHandler:
         self.hud = hud
         self.selected: int | None = None
         self.hud.found_city.disable()
+        self.hud.end_turn.disable()
+        self.hud.show_hint("Found a city to end your turn")
 
     def handle_event(self, event: pygame.event.Event, state: State) -> None:
         self.hud.process_event(event)
@@ -55,6 +57,8 @@ class InputHandler:
                         rules.found_city(state, self.selected)
                         self.selected = None
                         self.hud.found_city.disable()
+                        self.hud.end_turn.enable()
+                        self.hud.hide_hint()
                     except rules.RuleError:
                         pass
                 elif event.ui_element == self.hud.buy_scout:


### PR DESCRIPTION
## Summary
- Disable End Turn button until the human player establishes a city
- Display a hint prompting the player to found a city
- Enable End Turn and hide hint after founding a city

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f0fb81e48328b3c04c4e7ba9279f