### PR TITLE
Ensure scouts use correct starting moves

### DIFF
--- a/game/core/mapgen.py
+++ b/game/core/mapgen.py
@@ -51,7 +51,7 @@ def initial_units(spawns: List[Tuple[int, int]]) -> List[Unit]:
                 owner=owner,
                 kind="scout",
                 pos=pos,
-                moves_left=config.UNIT_STATS["settler"]["moves"],
+                moves_left=config.UNIT_STATS["scout"]["moves"],
             )
         )
         uid += 1

--- a/tests/test_mapgen.py
+++ b/tests/test_mapgen.py
@@ -1,0 +1,12 @@
+from game import config
+from game.core import mapgen
+
+
+def test_initial_unit_moves_left():
+    tiles, spawns = mapgen.generate_map(5, 5, seed=0)
+    units = mapgen.initial_units(spawns)
+    settler = next(u for u in units if u.kind == "settler")
+    scout = next(u for u in units if u.kind == "scout")
+    assert settler.moves_left == config.UNIT_STATS["settler"]["moves"]
+    assert scout.moves_left == config.UNIT_STATS["scout"]["moves"]
+    assert settler.moves_left != scout.moves_left

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -37,6 +37,7 @@ def test_win_condition():
     state = make_state()
     uid = next(uid for uid, u in state.units.items() if u.kind == "settler")
     state.units[uid].pos = (2, 2)
+    state.tile_at((2, 2)).kind = "plains"
     rules.found_city(state, uid)
     cid = next(iter(state.cities))
     state.cities[cid].owner = 1


### PR DESCRIPTION
## Summary
- Fix scout initialization to use the scout move stat instead of settler moves
- Test that settlers and scouts start with distinct `moves_left` values
- Stabilize win condition test by forcing founding tile to land

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f10b2f2c8328a29b602632daf6c3