### PR TITLE
Show current player's HUD resources

### DIFF
--- a/game/core/mapgen.py
+++ b/game/core/mapgen.py
@@ -10,7 +10,7 @@ from .models import Tile, Unit
 
 
 def generate_map(w: int, h: int, seed: int) -> Tuple[List[Tile], List[Tuple[int, int]]]:
-    rng = Random()
+    rng = Random(seed)
     tiles: List[Tile] = []
     for y in range(h):
         for x in range(w):

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -41,9 +41,10 @@ class HUD:
         self.manager.process_events(event)
 
     def update(self, time_delta: float, state: State) -> None:
+        player = state.players[state.current_player]
         self.info.set_text(
             f"Turn {state.turn} Player {state.current_player} "
-            f"F:{state.players[0].food} P:{state.players[0].prod}"
+            f"F:{player.food} P:{player.prod}"
         )
         self.manager.update(time_delta)
 

--- a/tests/test_hud.py
+++ b/tests/test_hud.py
@@ -1,0 +1,32 @@
+import os
+
+os.environ.setdefault("SDL_VIDEODRIVER", "dummy")
+
+import pygame
+
+from game.core.models import Player, State, Tile
+from game.ui.hud import HUD
+
+
+def make_state() -> State:
+    tiles = [Tile(0, 0, "plains")]
+    players = {
+        0: Player(id=0, food=10, prod=5),
+        1: Player(id=1, food=1, prod=2),
+    }
+    return State(1, 1, tiles, {}, {}, players, current_player=0)
+
+
+def test_hud_switches_resource_display_with_current_player() -> None:
+    pygame.init()
+    pygame.display.set_mode((1, 1))
+    hud = HUD(pygame.Rect(0, 0, 640, 480))
+    state = make_state()
+
+    hud.update(0.0, state)
+    assert "F:10 P:5" in hud.info.text
+
+    state.current_player = 1
+    hud.update(0.0, state)
+    assert "F:1 P:2" in hud.info.text
+    pygame.quit()


### PR DESCRIPTION
## Summary
- ensure HUD reflects the current player's food and production
- add HUD test verifying resource display switches with `current_player`
- seed map generation for deterministic tests

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f10c13a48328a9def9f0fe82f319