### PR TITLE
Show HUD messages for rule errors

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -12,36 +12,42 @@ class HUD:
     def __init__(self, rect: pygame.Rect) -> None:
         self.manager = pygame_gui.UIManager(rect.size)
         self.end_turn = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(10, 10, 80, 40),
+            relative_rect=pygame.Rect(10, 5, 80, 30),
             text="End Turn",
             manager=self.manager,
         )
         self.found_city = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(100, 10, 100, 40),
+            relative_rect=pygame.Rect(100, 5, 100, 30),
             text="Found City",
             manager=self.manager,
         )
         self.buy_scout = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(210, 10, 100, 40),
+            relative_rect=pygame.Rect(210, 5, 100, 30),
             text="Buy Scout",
             manager=self.manager,
         )
         self.buy_soldier = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(320, 10, 100, 40),
+            relative_rect=pygame.Rect(320, 5, 100, 30),
             text="Buy Soldier",
             manager=self.manager,
         )
         self.info = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(430, 10, 200, 40),
+            relative_rect=pygame.Rect(430, 5, 200, 30),
             text="",
             manager=self.manager,
         )
         self.hint = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(10, 50, 300, 20),
+            relative_rect=pygame.Rect(10, 40, 300, 20),
             text="",
             manager=self.manager,
         )
         self.hint.hide()
+        self.message = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(320, 40, 300, 20),
+            text="",
+            manager=self.manager,
+        )
+        self.message.hide()
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)
@@ -63,3 +69,11 @@ class HUD:
 
     def hide_hint(self) -> None:
         self.hint.hide()
+
+    def show_message(self, text: str) -> None:
+        """Display a transient warning or info message."""
+        self.message.set_text(text)
+        self.message.show()
+
+    def hide_message(self) -> None:
+        self.message.hide()

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -18,6 +18,7 @@ class InputHandler:
         self.hud.found_city.disable()
         self.hud.end_turn.disable()
         self.hud.show_hint("Found a city to end your turn")
+        self.hud.hide_message()
 
     def handle_event(self, event: pygame.event.Event, state: State) -> None:
         self.hud.process_event(event)
@@ -46,15 +47,20 @@ class InputHandler:
                 dest = (x // config.TILE_SIZE, y // config.TILE_SIZE)
                 try:
                     rules.move_unit(state, self.selected, dest)
-                except (rules.RuleError, KeyError):
-                    pass
+                    self.hud.hide_message()
+                except rules.RuleError as e:
+                    self.hud.show_message(str(e))
+                except KeyError:
+                    self.hud.show_message("Cannot move there")
             else:
                 self.selected = None
                 self.hud.found_city.disable()
+                self.hud.show_message("No unit selected")
         elif event.type == pygame.USEREVENT:
             if event.user_type == pygame_gui.UI_BUTTON_PRESSED:
                 if event.ui_element == self.hud.end_turn:
                     rules.end_turn(state)
+                    self.hud.hide_message()
                 elif (
                     event.ui_element == self.hud.found_city
                     and self.selected is not None
@@ -65,7 +71,13 @@ class InputHandler:
                         rules.found_city(state, self.selected)
                         self.selected = None
                         self.hud.found_city.disable()
-                    except (rules.RuleError, KeyError):
+                        self.hud.hide_message()
+                    except rules.RuleError as e:
+                        self.hud.show_message(str(e))
+                        self.selected = None
+                        self.hud.found_city.disable()
+                    except KeyError:
+                        self.hud.show_message("Cannot found city")
                         self.selected = None
                         self.hud.found_city.disable()
 
@@ -74,14 +86,20 @@ class InputHandler:
                         if city.owner == state.current_player:
                             try:
                                 rules.buy_unit(state, city.id, "scout")
-                            except (rules.RuleError, KeyError):
-                                pass
+                                self.hud.hide_message()
+                            except rules.RuleError as e:
+                                self.hud.show_message(str(e))
+                            except KeyError:
+                                self.hud.show_message("Cannot buy unit")
                             break
                 elif event.ui_element == self.hud.buy_soldier:
                     for city in state.cities.values():
                         if city.owner == state.current_player:
                             try:
                                 rules.buy_unit(state, city.id, "soldier")
-                            except (rules.RuleError, KeyError):
-                                pass
+                                self.hud.hide_message()
+                            except rules.RuleError as e:
+                                self.hud.show_message(str(e))
+                            except KeyError:
+                                self.hud.show_message("Cannot buy unit")
                             break


### PR DESCRIPTION
## Summary
- Add HUD.message label and methods to show or hide warnings and info
- Route rule violations and other notices through hud.show_message
- Reposition HUD widgets so buttons, hints, and warnings occupy distinct areas

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f4491734832885c6821c3f2a3744