### PR TITLE
Add hover details for map elements

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -36,8 +36,14 @@ class HUD:
             text="",
             manager=self.manager,
         )
-        self.hint = pygame_gui.elements.UILabel(
+        self.hover = pygame_gui.elements.UILabel(
             relative_rect=pygame.Rect(10, 50, 300, 20),
+            text="",
+            manager=self.manager,
+        )
+        self.hover.hide()
+        self.hint = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(320, 50, 300, 20),
             text="",
             manager=self.manager,
         )
@@ -63,3 +69,12 @@ class HUD:
 
     def hide_hint(self) -> None:
         self.hint.hide()
+
+    def set_hover_info(self, text: str) -> None:
+        """Display hover information about map elements."""
+        self.hover.set_text(text)
+        self.hover.show()
+
+    def clear_hover_info(self) -> None:
+        """Hide hover information."""
+        self.hover.hide()

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -24,7 +24,30 @@ class InputHandler:
         if self.selected is not None and self.selected not in state.units:
             self.selected = None
             self.hud.found_city.disable()
-        if event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
+        if event.type == pygame.MOUSEMOTION:
+            x, y = event.pos
+            if (
+                y >= state.height * config.TILE_SIZE
+                or x < 0
+                or x >= state.width * config.TILE_SIZE
+            ):
+                self.hud.clear_hover_info()
+                return
+            coord = (x // config.TILE_SIZE, y // config.TILE_SIZE)
+            units = state.units_at(coord)
+            if units:
+                unit = units[0]
+                text = f"{unit.kind} (Player {unit.owner})"
+            else:
+                city = state.city_at(coord)
+                if city is not None:
+                    text = f"City (Player {city.owner})"
+                else:
+                    tile = state.tile_at(coord)
+                    food, prod = config.YIELD[tile.kind]
+                    text = f"{tile.kind} F:{food} P:{prod}"
+            self.hud.set_hover_info(text)
+        elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             x, y = event.pos
             tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
             self.selected = None


### PR DESCRIPTION
## Summary
- show unit, city, or tile info when moving mouse over map
- allow HUD to display and clear hover information

## Testing
- `ruff check game/ui/hud.py game/ui/input.py`
- `python -m black game/ui/hud.py game/ui/input.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f44a469083288b89eac1bd382ef1