### PR TITLE
Add bottom-corner HUD labels for hover info and warnings

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -10,6 +10,7 @@ from ..core.models import State
 
 class HUD:
     def __init__(self, rect: pygame.Rect) -> None:
+        self.rect = rect
         self.manager = pygame_gui.UIManager(rect.size)
         self.end_turn = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(10, 10, 80, 40),
@@ -36,12 +37,23 @@ class HUD:
             text="",
             manager=self.manager,
         )
-        self.hint = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(10, 50, 300, 20),
+        self.hover_info = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(
+                self.rect.width - 210, self.rect.height - 30, 200, 20
+            ),
             text="",
             manager=self.manager,
         )
-        self.hint.hide()
+        self.hover_info.hide()
+        self.message = pygame_gui.elements.UILabel(
+            relative_rect=pygame.Rect(10, self.rect.height - 30, 300, 20),
+            text="",
+            manager=self.manager,
+        )
+        self.message.text_colour = pygame.Color("red")
+        self.message.rebuild()
+        self.message.hide()
+        self._message_timer: float | None = None
 
     def process_event(self, event: pygame.event.Event) -> None:
         self.manager.process_events(event)
@@ -52,14 +64,24 @@ class HUD:
             f"Turn {state.turn} Player {state.current_player} "
             f"F:{player.food} P:{player.prod}"
         )
+        if self._message_timer is not None:
+            self._message_timer -= time_delta
+            if self._message_timer <= 0:
+                self.message.hide()
+                self._message_timer = None
         self.manager.update(time_delta)
 
     def draw(self, surface: pygame.Surface) -> None:
         self.manager.draw_ui(surface)
 
-    def show_hint(self, text: str) -> None:
-        self.hint.set_text(text)
-        self.hint.show()
+    def set_hover_info(self, text: str) -> None:
+        self.hover_info.set_text(text)
+        self.hover_info.show()
 
-    def hide_hint(self) -> None:
-        self.hint.hide()
+    def clear_hover_info(self) -> None:
+        self.hover_info.hide()
+
+    def show_message(self, text: str, timeout: float | None = None) -> None:
+        self.message.set_text(text)
+        self.message.show()
+        self._message_timer = timeout

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -17,7 +17,7 @@ class InputHandler:
         self.selected: int | None = None
         self.hud.found_city.disable()
         self.hud.end_turn.disable()
-        self.hud.show_hint("Found a city to end your turn")
+        self.hud.show_message("Found a city to end your turn")
 
     def handle_event(self, event: pygame.event.Event, state: State) -> None:
         self.hud.process_event(event)


### PR DESCRIPTION
## Summary
- Add hover info and warning message labels anchored to screen corners
- Track HUD rect for positioning and auto-hide timed messages
- Replace hint API with hover info, message helpers and update input handler

## Testing
- `ruff check game/ui/hud.py game/ui/input.py`
- `black game/ui/hud.py game/ui/input.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7f44aa4bc8328b25fd7e13904ac0b