### PR TITLE
fix: preserve selection when clicking HUD

### DIFF
--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -49,6 +49,8 @@ class InputHandler:
             self.hud.set_hover_info(text)
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             x, y = event.pos
+            if y >= state.height * config.TILE_SIZE:
+                return
             tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
             self.selected = None
             for unit in state.units.values():


### PR DESCRIPTION
## Summary
- guard against left clicks below the map so HUD interactions don't clear the active unit

## Testing
- `ruff check .`
- `black .`
- `pytest -q`
- `python -m game.main` *(fails: unable to interact, headless environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a8944a170c8328966944fef2b13d52