### PR TITLE
Add keyboard hotkeys for game actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ pip install -r requirements.txt
 python -m game.main
 ```
 
+## Controls
+
+- **W/A/S/D**: move selected unit
+- **F**: found city
+- **Enter**: end turn
+- **Q**: quit game
+
 ## Tests
 ```bash
 pytest -q

--- a/agents.md
+++ b/agents.md
@@ -79,7 +79,7 @@ This document tells a code-generating agent exactly what to build and how to str
 
 ### UX
 
-* Left-click to select; right-click to move. Buttons: End Turn, Found City, Buy Unit (Soldier/Scout) if at city and enough production.
+* Left-click to select; right-click to move. Buttons: End Turn, Found City, Buy Unit (Soldier/Scout) if at city and enough production. Hotkeys: **W/A/S/D** to move, **F** to found city, **Enter** to end turn, **Q** to quit.
 * HUD shows: current player, turn number, resources, selected unit info.
 
 ---

--- a/game/scenes/gameplay.py
+++ b/game/scenes/gameplay.py
@@ -38,6 +38,8 @@ class Gameplay:
             for event in pygame.event.get():
                 if event.type == pygame.QUIT:
                     running = False
+                elif event.type == pygame.KEYDOWN and event.key == pygame.K_q:
+                    running = False
                 else:
                     self.input.handle_event(event, self.state)
             if self.state.current_player == 1:

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -80,6 +80,49 @@ class InputHandler:
                 self.selected = None
                 self.hud.found_city.disable()
                 self.hud.show_message("No unit selected")
+        elif event.type == pygame.KEYDOWN:
+            if (
+                self.selected is not None
+                and self.selected in state.units
+                and event.key in {pygame.K_w, pygame.K_a, pygame.K_s, pygame.K_d}
+            ):
+                unit = state.units[self.selected]
+                dx, dy = {
+                    pygame.K_w: (0, -1),
+                    pygame.K_s: (0, 1),
+                    pygame.K_a: (-1, 0),
+                    pygame.K_d: (1, 0),
+                }[event.key]
+                dest = (unit.pos[0] + dx, unit.pos[1] + dy)
+                try:
+                    rules.move_unit(state, self.selected, dest)
+                    self.hud.hide_message()
+                except rules.RuleError as e:
+                    self.hud.show_message(str(e))
+                except KeyError:
+                    self.hud.show_message("Cannot move there")
+            elif (
+                event.key == pygame.K_f
+                and self.selected is not None
+                and self.selected in state.units
+                and state.units[self.selected].kind == "settler"
+            ):
+                try:
+                    rules.found_city(state, self.selected)
+                    self.selected = None
+                    self.hud.found_city.disable()
+                    self.hud.hide_message()
+                except rules.RuleError as e:
+                    self.hud.show_message(str(e))
+                    self.selected = None
+                    self.hud.found_city.disable()
+                except KeyError:
+                    self.hud.show_message("Cannot found city")
+                    self.selected = None
+                    self.hud.found_city.disable()
+            elif event.key == pygame.K_RETURN:
+                rules.end_turn(state)
+                self.hud.hide_message()
         elif event.type == pygame.USEREVENT:
             if event.user_type == pygame_gui.UI_BUTTON_PRESSED:
                 if event.ui_element == self.hud.end_turn:


### PR DESCRIPTION
## Summary
- Add keyboard movement with WASD, F to found a city, Enter to end turn
- Allow quitting gameplay with Q key
- Document hotkeys in README and agents file

## Testing
- `ruff check .`
- `black game/ui/input.py game/scenes/gameplay.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a895d4987483288d5d92d2be64f213