### PR TITLE
Fix HUD clicks deselecting units

### DIFF
--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -11,30 +11,45 @@ from ..core.models import State
 class HUD:
     def __init__(self, rect: pygame.Rect) -> None:
         self.rect = rect
-        self.manager = pygame_gui.UIManager(rect.size)
+        # UIManager needs the full screen size so elements can be positioned
+        # anywhere. A panel constrained to ``rect`` holds all HUD widgets so
+        # that their coordinates are relative to the HUD area rather than the
+        # map. This prevents map click handling from interfering with HUD
+        # interactions.
+        screen_size = pygame.display.get_surface().get_size()
+        self.manager = pygame_gui.UIManager(screen_size)
+        self.panel = pygame_gui.elements.UIPanel(
+            relative_rect=self.rect,
+            manager=self.manager,
+        )
         self.end_turn = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(10, 5, 80, 30),
             text="End Turn",
+            container=self.panel,
             manager=self.manager,
         )
         self.found_city = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(100, 5, 100, 30),
             text="Found City",
+            container=self.panel,
             manager=self.manager,
         )
         self.buy_scout = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(210, 5, 100, 30),
             text="Buy Scout",
+            container=self.panel,
             manager=self.manager,
         )
         self.buy_soldier = pygame_gui.elements.UIButton(
             relative_rect=pygame.Rect(320, 5, 100, 30),
             text="Buy Soldier",
+            container=self.panel,
             manager=self.manager,
         )
         self.info = pygame_gui.elements.UILabel(
             relative_rect=pygame.Rect(430, 5, 200, 30),
             text="",
+            container=self.panel,
             manager=self.manager,
         )
         self.hover_info = pygame_gui.elements.UILabel(
@@ -42,12 +57,14 @@ class HUD:
                 self.rect.width - 210, self.rect.height - 30, 200, 20
             ),
             text="",
+            container=self.panel,
             manager=self.manager,
         )
         self.hover_info.hide()
         self.message = pygame_gui.elements.UILabel(
             relative_rect=pygame.Rect(10, self.rect.height - 30, 300, 20),
             text="",
+            container=self.panel,
             manager=self.manager,
         )
         self.message.text_colour = pygame.Color("red")

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -26,11 +26,12 @@ class InputHandler:
             self.hud.found_city.disable()
         if event.type == pygame.MOUSEMOTION:
             x, y = event.pos
-            if (
-                y >= state.height * config.TILE_SIZE
-                or x < 0
-                or x >= state.width * config.TILE_SIZE
-            ):
+            # Ignore motion outside the map area, including over the HUD,
+            # to prevent hover info from interfering with HUD interactions.
+            map_rect = pygame.Rect(
+                0, 0, state.width * config.TILE_SIZE, state.height * config.TILE_SIZE
+            )
+            if not map_rect.collidepoint(x, y):
                 self.hud.clear_hover_info()
                 return
             coord = (x // config.TILE_SIZE, y // config.TILE_SIZE)
@@ -49,7 +50,11 @@ class InputHandler:
             self.hud.set_hover_info(text)
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 1:
             x, y = event.pos
-            if y >= state.height * config.TILE_SIZE:
+            map_rect = pygame.Rect(
+                0, 0, state.width * config.TILE_SIZE, state.height * config.TILE_SIZE
+            )
+            if self.hud.rect.collidepoint(x, y) or not map_rect.collidepoint(x, y):
+                # Clicking HUD or outside the map should not affect selection.
                 return
             tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
             self.selected = None
@@ -66,8 +71,13 @@ class InputHandler:
             else:
                 self.hud.found_city.disable()
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
+            x, y = event.pos
+            map_rect = pygame.Rect(
+                0, 0, state.width * config.TILE_SIZE, state.height * config.TILE_SIZE
+            )
+            if self.hud.rect.collidepoint(x, y) or not map_rect.collidepoint(x, y):
+                return
             if self.selected is not None and self.selected in state.units:
-                x, y = event.pos
                 dest = (x // config.TILE_SIZE, y // config.TILE_SIZE)
                 try:
                     rules.move_unit(state, self.selected, dest)


### PR DESCRIPTION
## Summary
- Anchor HUD in its own panel separate from the map
- Ignore HUD area when processing map input to keep unit selection

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a895a3092c8328aab8c97134e5e239