### PR TITLE
Add settler buying and unit purchase menu

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -213,7 +213,11 @@ TILE_SIZE = 32
 UI_BAR_H = 64
 MOVE_COST = {"plains":1, "forest":2, "hill":2, "water":999}
 YIELD = {"plains": (1,1), "forest": (0,2), "hill": (0,2), "water": (0,0)}  # (food, prod)
-UNIT_STATS = {"scout": {"moves":3, "cost":3}, "soldier": {"moves":2, "cost":4}}
+UNIT_STATS = {
+    "scout": {"moves":3, "food":0, "prod":3},
+    "soldier": {"moves":2, "food":0, "prod":4},
+    "settler": {"moves":2, "food":2, "prod":1},
+}
 REVEAL_RADIUS = 3
 START_SIZE = (20, 12)
 ```
@@ -247,7 +251,7 @@ Use these structured prompts to generate specific parts. Replace `<<<...>>>` whe
 
 ### 14.4 UI & Loop
 
-> Create `game/ui/renderer.py`, `game/ui/hud.py`, `game/ui/input.py`, and `game/scenes/gameplay.py` to render grid, handle input intents, and wire to rules. Use `pygame_gui` for buttons (End Turn, Found City, Buy Scout, Buy Soldier). Keep code < 250 lines per file.
+> Create `game/ui/renderer.py`, `game/ui/hud.py`, `game/ui/input.py`, and `game/scenes/gameplay.py` to render grid, handle input intents, and wire to rules. Use `pygame_gui` for buttons (End Turn, Found City) and a Buy Unit menu (Scout, Soldier, Settler). Keep code < 250 lines per file.
 
 ### 14.5 Menu Scene
 

--- a/game/config.py
+++ b/game/config.py
@@ -3,9 +3,9 @@ UI_BAR_H = 64
 MOVE_COST = {"plains": 1, "forest": 2, "hill": 2, "water": 999}
 YIELD = {"plains": (1, 1), "forest": (0, 2), "hill": (0, 2), "water": (0, 0)}
 UNIT_STATS = {
-    "scout": {"moves": 3, "cost": 3},
-    "soldier": {"moves": 2, "cost": 4},
-    "settler": {"moves": 2, "cost": 5},
+    "scout": {"moves": 3, "food": 0, "prod": 3},
+    "soldier": {"moves": 2, "food": 0, "prod": 4},
+    "settler": {"moves": 2, "food": 2, "prod": 1},
 }
 REVEAL_RADIUS = 3
 START_SIZE = (20, 12)

--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -82,13 +82,16 @@ def buy_unit(state: State, city_id: int, kind: str) -> Unit:
     city = state.cities[city_id]
     if city.owner != state.current_player:
         raise RuleError("not your city")
-    cost = config.UNIT_STATS[kind]["cost"]
+    stats = config.UNIT_STATS[kind]
+    cost_food = stats.get("food", 0)
+    cost_prod = stats.get("prod", 0)
     player = state.players[city.owner]
-    if player.prod < cost:
-        raise RuleError("not enough production")
+    if player.food < cost_food or player.prod < cost_prod:
+        raise RuleError("not enough resources")
     if state.units_at(city.pos):
         raise RuleError("tile occupied")
-    player.prod -= cost
+    player.food -= cost_food
+    player.prod -= cost_prod
     unit = Unit(
         id=state.next_unit_id,
         owner=city.owner,

--- a/game/ui/hud.py
+++ b/game/ui/hud.py
@@ -34,20 +34,16 @@ class HUD:
             container=self.panel,
             manager=self.manager,
         )
-        self.buy_scout = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(210, 5, 100, 30),
-            text="Buy Scout",
+        self.buy_unit = pygame_gui.elements.UIDropDownMenu(
+            options_list=["Buy Unit", "Buy Scout", "Buy Soldier", "Buy Settler"],
+            starting_option="Buy Unit",
+            relative_rect=pygame.Rect(210, 5, 150, 30),
             container=self.panel,
             manager=self.manager,
         )
-        self.buy_soldier = pygame_gui.elements.UIButton(
-            relative_rect=pygame.Rect(320, 5, 100, 30),
-            text="Buy Soldier",
-            container=self.panel,
-            manager=self.manager,
-        )
+        self.buy_unit.disable()
         self.info = pygame_gui.elements.UILabel(
-            relative_rect=pygame.Rect(430, 5, 200, 30),
+            relative_rect=pygame.Rect(370, 5, 200, 30),
             text="",
             container=self.panel,
             manager=self.manager,

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -15,7 +15,9 @@ class InputHandler:
     def __init__(self, hud: HUD) -> None:
         self.hud = hud
         self.selected: int | None = None
+        self.selected_city: int | None = None
         self.hud.found_city.disable()
+        self.hud.buy_unit.disable()
         self.hud.hide_message()
 
     def handle_event(self, event: pygame.event.Event, state: State) -> None:
@@ -23,6 +25,12 @@ class InputHandler:
         if self.selected is not None and self.selected not in state.units:
             self.selected = None
             self.hud.found_city.disable()
+        if self.selected_city is not None and (
+            self.selected_city not in state.cities
+            or state.cities[self.selected_city].owner != state.current_player
+        ):
+            self.selected_city = None
+            self.hud.buy_unit.disable()
         if event.type == pygame.MOUSEMOTION:
             x, y = event.pos
             # Ignore motion outside the map area, including over the HUD,
@@ -57,6 +65,8 @@ class InputHandler:
                 return
             tile = (x // config.TILE_SIZE, y // config.TILE_SIZE)
             self.selected = None
+            self.selected_city = None
+            self.hud.buy_unit.disable()
             for unit in state.units.values():
                 if unit.pos == tile and unit.owner == state.current_player:
                     self.selected = unit.id
@@ -69,6 +79,10 @@ class InputHandler:
                 self.hud.found_city.enable()
             else:
                 self.hud.found_city.disable()
+                city = state.city_at(tile)
+                if city and city.owner == state.current_player:
+                    self.selected_city = city.id
+                    self.hud.buy_unit.enable()
         elif event.type == pygame.MOUSEBUTTONDOWN and event.button == 3:
             x, y = event.pos
             map_rect = pygame.Rect(
@@ -87,7 +101,9 @@ class InputHandler:
                     self.hud.show_message("Cannot move there")
             else:
                 self.selected = None
+                self.selected_city = None
                 self.hud.found_city.disable()
+                self.hud.buy_unit.disable()
                 self.hud.show_message("No unit selected")
         elif event.type == pygame.KEYDOWN:
             if (
@@ -117,25 +133,39 @@ class InputHandler:
                 and state.units[self.selected].kind == "settler"
             ):
                 try:
-                    rules.found_city(state, self.selected)
+                    city = rules.found_city(state, self.selected)
                     self.selected = None
+                    self.selected_city = city.id
                     self.hud.found_city.disable()
+                    self.hud.buy_unit.enable()
                     self.hud.hide_message()
                 except rules.RuleError as e:
                     self.hud.show_message(str(e))
                     self.selected = None
+                    self.selected_city = None
                     self.hud.found_city.disable()
+                    self.hud.buy_unit.disable()
                 except KeyError:
                     self.hud.show_message("Cannot found city")
                     self.selected = None
+                    self.selected_city = None
                     self.hud.found_city.disable()
+                    self.hud.buy_unit.disable()
             elif event.key == pygame.K_RETURN:
                 rules.end_turn(state)
+                self.selected = None
+                self.selected_city = None
+                self.hud.found_city.disable()
+                self.hud.buy_unit.disable()
                 self.hud.hide_message()
         elif event.type == pygame.USEREVENT:
             if event.user_type == pygame_gui.UI_BUTTON_PRESSED:
                 if event.ui_element == self.hud.end_turn:
                     rules.end_turn(state)
+                    self.selected = None
+                    self.selected_city = None
+                    self.hud.found_city.disable()
+                    self.hud.buy_unit.disable()
                     self.hud.hide_message()
                 elif (
                     event.ui_element == self.hud.found_city
@@ -144,38 +174,35 @@ class InputHandler:
                     and state.units[self.selected].kind == "settler"
                 ):
                     try:
-                        rules.found_city(state, self.selected)
+                        city = rules.found_city(state, self.selected)
                         self.selected = None
+                        self.selected_city = city.id
                         self.hud.found_city.disable()
+                        self.hud.buy_unit.enable()
                         self.hud.hide_message()
                     except rules.RuleError as e:
                         self.hud.show_message(str(e))
                         self.selected = None
+                        self.selected_city = None
                         self.hud.found_city.disable()
+                        self.hud.buy_unit.disable()
                     except KeyError:
                         self.hud.show_message("Cannot found city")
                         self.selected = None
+                        self.selected_city = None
                         self.hud.found_city.disable()
-
-                elif event.ui_element == self.hud.buy_scout:
-                    for city in state.cities.values():
-                        if city.owner == state.current_player:
-                            try:
-                                rules.buy_unit(state, city.id, "scout")
-                                self.hud.hide_message()
-                            except rules.RuleError as e:
-                                self.hud.show_message(str(e))
-                            except KeyError:
-                                self.hud.show_message("Cannot buy unit")
-                            break
-                elif event.ui_element == self.hud.buy_soldier:
-                    for city in state.cities.values():
-                        if city.owner == state.current_player:
-                            try:
-                                rules.buy_unit(state, city.id, "soldier")
-                                self.hud.hide_message()
-                            except rules.RuleError as e:
-                                self.hud.show_message(str(e))
-                            except KeyError:
-                                self.hud.show_message("Cannot buy unit")
-                            break
+                        self.hud.buy_unit.disable()
+            elif (
+                event.user_type == pygame_gui.UI_DROP_DOWN_MENU_CHANGED
+                and event.ui_element == self.hud.buy_unit
+            ):
+                if self.selected_city is not None and event.text != "Buy Unit":
+                    kind = event.text.split()[-1].lower()
+                    try:
+                        rules.buy_unit(state, self.selected_city, kind)
+                        self.hud.hide_message()
+                    except rules.RuleError as e:
+                        self.hud.show_message(str(e))
+                    except KeyError:
+                        self.hud.show_message("Cannot buy unit")
+                self.hud.buy_unit.set_selected_option("Buy Unit")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -33,6 +33,20 @@ def test_found_city_and_buy_unit():
     assert any(u.kind == "soldier" for u in state.units.values())
 
 
+def test_buy_settler_costs_food_and_production():
+    state = make_state()
+    uid = next(uid for uid, u in state.units.items() if u.kind == "settler")
+    state.units[uid].pos = (2, 2)
+    rules.found_city(state, uid)
+    cid = next(iter(state.cities))
+    player = state.players[0]
+    player.food = 2
+    player.prod = 1
+    rules.buy_unit(state, cid, "settler")
+    assert any(u.kind == "settler" for u in state.units.values())
+    assert player.food == 0 and player.prod == 0
+
+
 def test_win_condition():
     state = make_state()
     uid = next(uid for uid, u in state.units.items() if u.kind == "settler")


### PR DESCRIPTION
## Summary
- Allow settlers to be bought with food and production
- Add Buy Unit dropdown to HUD for scouts, soldiers and settlers
- Enable unit buying only when a city is selected and test settler costs

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae98501883289f6998db328f1a64