### PR TITLE
Add city growth metadata

### DIFF
--- a/game/core/models.py
+++ b/game/core/models.py
@@ -30,6 +30,12 @@ class City:
     id: int
     owner: int
     pos: Coord
+    size: int = 1
+    claimed: Set[Coord] = field(default_factory=set)
+
+    def claim(self, coord: Coord) -> None:
+        """Add a coordinate to the city's claimed tiles."""
+        self.claimed.add(coord)
 
 
 @dataclass
@@ -67,10 +73,10 @@ class State:
 
 
 __all__ = [
-    "Coord",
-    "Tile",
-    "Unit",
     "City",
+    "Coord",
     "Player",
     "State",
+    "Tile",
+    "Unit",
 ]


### PR DESCRIPTION
## Summary
- expand City dataclass with `size` and `claimed` fields
- add helper method `City.claim` and export ordering updates

## Testing
- `ruff check game/core/models.py`
- `black game/core/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7ff415c83288600dcf9a52deefd