### PR TITLE
feat: highlight selected city territory

### DIFF
--- a/game/scenes/gameplay.py
+++ b/game/scenes/gameplay.py
@@ -45,7 +45,12 @@ class Gameplay:
             if self.state.current_player == 1:
                 ai.ai_turn(self.state, rng)
             self.hud.update(time_delta, self.state)
-            draw(self.state, self.screen, self.input.selected)
+            draw(
+                self.state,
+                self.screen,
+                self.input.selected,
+                self.input.selected_city,
+            )
             self.hud.draw(self.screen)
             pygame.display.flip()
             if check_win(self.state) is not None:

--- a/game/ui/input.py
+++ b/game/ui/input.py
@@ -100,11 +100,13 @@ class InputHandler:
                 except KeyError:
                     self.hud.show_message("Cannot move there")
             else:
+                # Do not clear a selected city when right-clicking with no unit
+                # selected so its claimed tiles remain highlighted.
                 self.selected = None
-                self.selected_city = None
                 self.hud.found_city.disable()
-                self.hud.buy_unit.disable()
-                self.hud.show_message("No unit selected")
+                if self.selected_city is None:
+                    self.hud.buy_unit.disable()
+                    self.hud.show_message("No unit selected")
         elif event.type == pygame.KEYDOWN:
             if (
                 self.selected is not None

--- a/game/ui/renderer.py
+++ b/game/ui/renderer.py
@@ -22,7 +22,12 @@ COLORS = {
 HIGHLIGHT_COLOR = (255, 255, 0)
 
 
-def draw(state: State, surface: pygame.Surface, selected_id: int | None = None) -> None:
+def draw(
+    state: State,
+    surface: pygame.Surface,
+    selected_unit_id: int | None = None,
+    selected_city_id: int | None = None,
+) -> None:
     ts = config.TILE_SIZE
     for tile in state.tiles:
         rect = pygame.Rect(tile.x * ts, tile.y * ts, ts, ts)
@@ -36,8 +41,14 @@ def draw(state: State, surface: pygame.Surface, selected_id: int | None = None) 
     for unit in state.units.values():
         rect = pygame.Rect(unit.pos[0] * ts + 8, unit.pos[1] * ts + 8, ts - 16, ts - 16)
         surface.fill(COLORS[unit.kind], rect)
-    if selected_id is not None and selected_id in state.units:
-        unit = state.units[selected_id]
+    if selected_city_id is not None and selected_city_id in state.cities:
+        city = state.cities[selected_city_id]
+        claimed = getattr(city, "claimed", {city.pos})
+        for coord in claimed:
+            rect = pygame.Rect(coord[0] * ts, coord[1] * ts, ts, ts)
+            pygame.draw.rect(surface, HIGHLIGHT_COLOR, rect, 2)
+    if selected_unit_id is not None and selected_unit_id in state.units:
+        unit = state.units[selected_unit_id]
         tile = state.tile_at(unit.pos)
         if state.current_player in tile.revealed_by:
             rect = pygame.Rect(unit.pos[0] * ts, unit.pos[1] * ts, ts, ts)


### PR DESCRIPTION
## Summary
- highlight tiles claimed by a selected city
- keep city selection when right-clicking with no unit selected
- pass selected city from gameplay to renderer

## Testing
- `ruff check game/ui/renderer.py game/ui/input.py game/scenes/gameplay.py`
- `black game/ui/renderer.py game/ui/input.py game/scenes/gameplay.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b80253208328bfe8cd20d97f5998