### PR TITLE
Include city territory in save data

### DIFF
--- a/game/core/models.py
+++ b/game/core/models.py
@@ -30,6 +30,8 @@ class City:
     id: int
     owner: int
     pos: Coord
+    size: Set[Coord] = field(default_factory=set)
+    claimed: Set[Coord] = field(default_factory=set)
 
 
 @dataclass

--- a/game/core/saveio.py
+++ b/game/core/saveio.py
@@ -28,7 +28,13 @@ def state_to_dict(state: State) -> Dict[str, Any]:
             for uid, u in state.units.items()
         },
         "cities": {
-            cid: {"id": c.id, "owner": c.owner, "pos": list(c.pos)}
+            cid: {
+                "id": c.id,
+                "owner": c.owner,
+                "pos": list(c.pos),
+                "size": [list(s) for s in sorted(c.size)],
+                "claimed": [list(s) for s in sorted(c.claimed)],
+            }
             for cid, c in state.cities.items()
         },
         "players": {
@@ -58,7 +64,13 @@ def dict_to_state(data: Dict[str, Any]) -> State:
         for uid, u in data["units"].items()
     }
     cities = {
-        int(cid): City(id=c["id"], owner=c["owner"], pos=tuple(c["pos"]))
+        int(cid): City(
+            id=c["id"],
+            owner=c["owner"],
+            pos=tuple(c["pos"]),
+            size={tuple(s) for s in c.get("size", [])},
+            claimed={tuple(s) for s in c.get("claimed", [])},
+        )
         for cid, c in data["cities"].items()
     }
     players = {int(pid): Player(**p) for pid, p in data["players"].items()}

--- a/tests/test_saveio.py
+++ b/tests/test_saveio.py
@@ -1,15 +1,23 @@
 import tempfile
 
 from game.core import mapgen, saveio
-from game.core.models import Player, State
+from game.core.models import City, Player, State
 
 
 def make_state() -> State:
     tiles, spawns = mapgen.generate_map(5, 5, seed=3)
     units = {u.id: u for u in mapgen.initial_units(spawns)}
     players = {0: Player(0), 1: Player(1)}
-    state = State(5, 5, tiles, units, {}, players)
+    city = City(
+        id=1,
+        owner=0,
+        pos=(2, 2),
+        size={(2, 2), (3, 2)},
+        claimed={(2, 2), (2, 3)},
+    )
+    state = State(5, 5, tiles, units, {city.id: city}, players)
     state.next_unit_id = max(units) + 1
+    state.next_city_id = 2
     return state
 
 


### PR DESCRIPTION
## Summary
- Track `size` and `claimed` tiles for each city in models
- Persist city territory during save/load cycles
- Add round-trip test covering city territory serialization

## Testing
- `black .`
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8033070832892c835714c29304d