### PR TITLE
Add deterministic tests for city expansion and yields

### DIFF
--- a/game/core/models.py
+++ b/game/core/models.py
@@ -30,6 +30,9 @@ class City:
     id: int
     owner: int
     pos: Coord
+    claimed: Set[Coord] = field(default_factory=set)
+    size: int = 1
+    food_stock: int = 0
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Track claimed tiles, size, and food stock on cities
- Expand city territory using deterministic RNG during founding and growth
- Test that city expansion, growth, and yields behave deterministically

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b8047b4483289df050c650060117