### PR TITLE
Deduct food on city growth and display city size

### DIFF
--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -111,8 +111,9 @@ def end_turn(state: State, rng: Random | None = None) -> None:
         player.food += total_food
         player.prod += total_prod
         city.food_stock += total_food
-        while city.food_stock >= 3:
+        while city.food_stock >= 3 and player.food >= 3:
             city.food_stock -= 3
+            player.food -= 3
             city.size += 1
             claim_best_tile(state, city, rng)
 

--- a/game/ui/renderer.py
+++ b/game/ui/renderer.py
@@ -20,6 +20,7 @@ COLORS = {
 }
 
 HIGHLIGHT_COLOR = (255, 255, 0)
+FONT: pygame.font.Font | None = None
 
 
 def draw(
@@ -28,6 +29,9 @@ def draw(
     selected_unit_id: int | None = None,
     selected_city_id: int | None = None,
 ) -> None:
+    global FONT
+    if FONT is None:
+        FONT = pygame.font.Font(None, 16)
     ts = config.TILE_SIZE
     for tile in state.tiles:
         rect = pygame.Rect(tile.x * ts, tile.y * ts, ts, ts)
@@ -38,6 +42,10 @@ def draw(
     for city in state.cities.values():
         rect = pygame.Rect(city.pos[0] * ts, city.pos[1] * ts, ts, ts)
         surface.fill(COLORS["city"], rect)
+        if FONT:
+            text = FONT.render(str(city.size), True, (0, 0, 0))
+            text_rect = text.get_rect(center=rect.center)
+            surface.blit(text, text_rect)
     for unit in state.units.values():
         rect = pygame.Rect(unit.pos[0] * ts + 8, unit.pos[1] * ts + 8, ts - 16, ts - 16)
         surface.fill(COLORS[unit.kind], rect)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -109,8 +109,10 @@ def test_city_grows_and_claims_new_tile():
     city = rules.found_city(state, uid, rng)
     rules.end_turn(state, rng)
     rules.end_turn(state, rng)
+    player = state.players[0]
     assert city.size == 2
     assert city.claimed == {(2, 2), (3, 2), (2, 1)}
+    assert player.food == 1
 
 
 def test_city_yield_sums_claimed_tiles():


### PR DESCRIPTION
## Summary
- Subtract player food whenever a city grows automatically
- Render city size as a number on the city tile
- Test city growth consumes player food

## Testing
- `ruff check game/core/rules.py game/ui/renderer.py tests/test_rules.py`
- `black game/core/rules.py game/ui/renderer.py tests/test_rules.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c08213dc8328850a5263b59a64eb