### PR TITLE
Reset unused production at turn end

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ you control a city or a settler, the game continues.
 Cities spend food to grow and automatically claim nearby tiles. Building
 farms, mines, sawmills, and roads on claimed tiles boosts yields and can reduce
 movement costs.
+Production cannot be stockpiled; unused production is lost at the end of each turn.
 
 ## Tests
 ```bash

--- a/game/core/rules.py
+++ b/game/core/rules.py
@@ -155,6 +155,8 @@ def claim_best_tile(state: State, city: City, rng: Random) -> bool:
 
 def end_turn(state: State, rng: Random | None = None) -> None:
     rng = rng or Random()
+    # discard unused production from the player whose turn just ended
+    state.players[state.current_player].prod = 0
     for city in state.cities.values():
         if not city.claimed:
             city.claimed.add(city.pos)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -198,6 +198,21 @@ def test_city_can_claim_water_tile():
     assert (player.food, player.prod) == (2, 1)
 
 
+def test_unused_production_lost_each_turn():
+    state = make_state()
+    uid = next(uid for uid, u in state.units.items() if u.kind == "settler")
+    state.units[uid].pos = (2, 2)
+    state.tile_at((2, 2)).kind = "plains"
+    for dx, dy in [(1, 0), (-1, 0), (0, 1), (0, -1)]:
+        state.tile_at((2 + dx, 2 + dy)).kind = "plains"
+    rng = Random(0)
+    rules.found_city(state, uid, rng)
+    player = state.players[0]
+    player.prod = 10
+    rules.end_turn(state, rng)
+    assert player.prod == 2
+
+
 def test_city_grows_only_once_per_turn():
     state = make_state()
     uid = next(uid for uid, u in state.units.items() if u.kind == "settler")


### PR DESCRIPTION
## Summary
- Clear a player's leftover production when their turn ends so new yields start fresh.
- Document the no-stockpiling rule for production in the README.
- Add regression test verifying production is reset at end of turn.

## Testing
- `ruff check .`
- `black .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa9d82bd088328aaa5eb75f933d9e7